### PR TITLE
Add content/support_tickets tab for bulk editing tickets

### DIFF
--- a/modules/support_ticket/config/optional/views.view.support_ticket_overview.yml
+++ b/modules/support_ticket/config/optional/views.view.support_ticket_overview.yml
@@ -1,0 +1,1215 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - support_ticket
+    - user
+id: support_ticket_overview
+label: 'Support ticket overview'
+module: views
+description: 'Find and manage support tickets.'
+tag: ''
+base_table: support_ticket_field_data
+base_field: stid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access support ticket overview'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: '‹ previous'
+            next: 'next ›'
+            first: '« first'
+            last: 'last »'
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            support_ticket_bulk_form: support_ticket_bulk_form
+            title: title
+            support_ticket_type: support_ticket_type
+            uid: uid
+            status: status
+            changed: changed
+            operations: operations
+          info:
+            support_ticket_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            support_ticket_type:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: true
+      row:
+        type: fields
+      fields:
+        support_ticket_bulk_form:
+          id: support_ticket_bulk_form
+          table: support_ticket
+          field: support_ticket_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: 'With selection'
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: support_ticket
+          plugin_id: support_ticket_bulk_form
+        title:
+          id: title
+          table: support_ticket_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: support_ticket
+          entity_field: title
+          plugin_id: field
+        support_ticket_type:
+          id: support_ticket_type
+          table: support_ticket_field_data
+          field: support_ticket_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Support Ticket Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: support_ticket
+          entity_field: support_ticket_type
+          plugin_id: field
+        uid:
+          id: uid
+          table: support_ticket_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: author
+          settings:
+            link: 0
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: support_ticket
+          entity_field: uid
+          plugin_id: field
+        status:
+          id: status
+          table: support_ticket_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: Published
+            format_custom_false: Unpublished
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: support_ticket
+          entity_field: status
+          plugin_id: field
+        changed:
+          id: changed
+          table: support_ticket_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Changed
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: support_ticket
+          entity_field: changed
+          plugin_id: field
+        operations:
+          id: operations
+          table: support_ticket
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          entity_type: support_ticket
+          plugin_id: entity_operations
+      filters:
+        status_extra:
+          id: status_extra
+          table: support_ticket_field_data
+          field: status_extra
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: false
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: support_ticket
+          plugin_id: support_ticket_status
+        title:
+          id: title
+          table: support_ticket_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              administrator1: '0'
+              consumersearch_tickets: '0'
+              tag1_jobtrack_tickets: '0'
+              tag1_accounting_tickets: '0'
+              tag1_administrative_tickets: '0'
+              tag1_adbard_tickets: '0'
+              uivote_tickets: '0'
+              bricodepot_tickets: '0'
+              webwise_tickets: '0'
+              parentsclick_tickets: '0'
+              pressflow_tickets: '0'
+              nowpublic_tickets: '0'
+              waste_management_tickets: '0'
+              calorie_count_tickets: '0'
+              sandusky_register_tickets: '0'
+              fsf_tickets: '0'
+              ad_module_tickets: '0'
+              shannon_mccormick_tickets: '0'
+              define_tickets: '0'
+              blue_moon_fiber_arts_tickets: '0'
+              open_source_lab_tickets: '0'
+              ifood_tickets: '0'
+              imagex_tickets: '0'
+              globale_oneness_tickets: '0'
+              dalton_tickets: '0'
+              goldbelt_tickets: '0'
+              empowher_tickets: '0'
+              f123_tickets: '0'
+              tag1_employee: '0'
+              blackmesh_tickets: '0'
+              tag1_theme_tickets: '0'
+              read_tickets: '0'
+              test_client_tickets: '0'
+              examiner_tickets: '0'
+              drupal_association_tickets: '0'
+              tag1_accounting: '0'
+              fishhound_tickets: '0'
+              penton_tickets: '0'
+              mark_boulton_design_tickets: '0'
+              tag1_contractor: '0'
+              acquia_tickets: '0'
+              _account_manager: '0'
+              zinch_tickets: '0'
+              tag1_manager: '0'
+              tidal_tickets: '0'
+              acquia_memcache_tickets: '0'
+              tag1_billable: '0'
+              tag1_terminated: '0'
+              puzzle_nation_tickets: '0'
+              environmental_graffiti_tickets: '0'
+              dustland_media_tickets: '0'
+              tag1_subcontractor: '0'
+              acquia_wiki_pages: '0'
+              _use_ticket_references: '0'
+              mixedbin_media_tickets: '0'
+              ideafit_tickets: '0'
+              inside_higher_ed_tickets: '0'
+              itv_tickets: '0'
+              vibio_tickets: '0'
+              megeve_tourisme_tickets: '0'
+              who2_tickets: '0'
+              polycom_tickets: '0'
+              tag1_contractor_hourly: '0'
+              stratfor_tickets: '0'
+              sunshine_state_news_tickets: '0'
+              funny_monkey_tickets: '0'
+              opensesame_tickets: '0'
+              smithsonian_tickets: '0'
+              tussle_tickets: '0'
+              incap_tickets: '0'
+              strand_scientific_intelligence_t: '0'
+              upto_tickets: '0'
+              are_you_a_human_tickets: '0'
+              center_for_reproductive_rights_t: '0'
+              archetype_tickets: '0'
+              bounty_tickets: '0'
+              bryant_group_tickets: '0'
+              cirracore_tickets: '0'
+              archetype_fueled_tickets: '0'
+              apple_tickets: '0'
+              edelman_tickets: '0'
+              facelift_designs_tickets: '0'
+              mmis_tickets: '0'
+              alloy_digital_tickets: '0'
+              mmis_dev_tickets: '0'
+              university_of_colorado_tickets: '0'
+              prime_resource_group_tickets: '0'
+              drupal_watchdog_tickets: '0'
+              codename_design_tickets: '0'
+              highwire_press_tickets: '0'
+              actency_tickets: '0'
+              centretek_tickets: '0'
+              common_sense_media_tickets: '0'
+              tag1_ckeditor_comment_tickets: '0'
+              palantir_tickets: '0'
+              designhammer_tickets: '0'
+              practice_greenhealth_tickets: '0'
+              taunton_interactive_tickets: '0'
+              linux_foundation_tickets: '0'
+              national_retail_foundation_nrf_t: '0'
+              pgh_tickets: '0'
+              daemon_defense_tickets: '0'
+              perforce_software_tickets: '0'
+              leadoutcome_tickets: '0'
+              civicsolar_tickets: '0'
+              maplight_tickets: '0'
+              mcmurry_tmg_tickets: '0'
+              aclu_tickets: '0'
+              tag1_website_tickets: '0'
+              tag1_infrastructure_tickets: '0'
+              stand_for_children_tickets: '0'
+              okoban_tickets: '0'
+              okoban_mindtek_tickets: '0'
+              axelerant_tickets: '0'
+              aclu_affiliates_tickets: '0'
+              mentor_graphics_tickets: '0'
+              brmcloud_tickets: '0'
+              kixify_tickets: '0'
+              young_writers_project_tickets: '0'
+              tag1_billing_overview_private_: '0'
+              lf_cla_tickets: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: support_ticket
+          entity_field: title
+          plugin_id: string
+        uid:
+          id: uid
+          table: support_ticket_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: uid_op
+            label: Author
+            description: ''
+            use_operator: false
+            operator: uid_op
+            identifier: uid
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              administrator1: '0'
+              consumersearch_tickets: '0'
+              tag1_jobtrack_tickets: '0'
+              tag1_accounting_tickets: '0'
+              tag1_administrative_tickets: '0'
+              tag1_adbard_tickets: '0'
+              uivote_tickets: '0'
+              bricodepot_tickets: '0'
+              webwise_tickets: '0'
+              parentsclick_tickets: '0'
+              pressflow_tickets: '0'
+              nowpublic_tickets: '0'
+              waste_management_tickets: '0'
+              calorie_count_tickets: '0'
+              sandusky_register_tickets: '0'
+              fsf_tickets: '0'
+              ad_module_tickets: '0'
+              shannon_mccormick_tickets: '0'
+              define_tickets: '0'
+              blue_moon_fiber_arts_tickets: '0'
+              open_source_lab_tickets: '0'
+              ifood_tickets: '0'
+              imagex_tickets: '0'
+              globale_oneness_tickets: '0'
+              dalton_tickets: '0'
+              goldbelt_tickets: '0'
+              empowher_tickets: '0'
+              f123_tickets: '0'
+              tag1_employee: '0'
+              blackmesh_tickets: '0'
+              tag1_theme_tickets: '0'
+              read_tickets: '0'
+              test_client_tickets: '0'
+              examiner_tickets: '0'
+              drupal_association_tickets: '0'
+              tag1_accounting: '0'
+              fishhound_tickets: '0'
+              penton_tickets: '0'
+              mark_boulton_design_tickets: '0'
+              tag1_contractor: '0'
+              acquia_tickets: '0'
+              _account_manager: '0'
+              zinch_tickets: '0'
+              tag1_manager: '0'
+              tidal_tickets: '0'
+              acquia_memcache_tickets: '0'
+              tag1_billable: '0'
+              tag1_terminated: '0'
+              puzzle_nation_tickets: '0'
+              environmental_graffiti_tickets: '0'
+              dustland_media_tickets: '0'
+              tag1_subcontractor: '0'
+              acquia_wiki_pages: '0'
+              _use_ticket_references: '0'
+              mixedbin_media_tickets: '0'
+              ideafit_tickets: '0'
+              inside_higher_ed_tickets: '0'
+              itv_tickets: '0'
+              vibio_tickets: '0'
+              megeve_tourisme_tickets: '0'
+              who2_tickets: '0'
+              polycom_tickets: '0'
+              tag1_contractor_hourly: '0'
+              stratfor_tickets: '0'
+              sunshine_state_news_tickets: '0'
+              funny_monkey_tickets: '0'
+              opensesame_tickets: '0'
+              smithsonian_tickets: '0'
+              tussle_tickets: '0'
+              incap_tickets: '0'
+              strand_scientific_intelligence_t: '0'
+              upto_tickets: '0'
+              are_you_a_human_tickets: '0'
+              center_for_reproductive_rights_t: '0'
+              archetype_tickets: '0'
+              bounty_tickets: '0'
+              bryant_group_tickets: '0'
+              cirracore_tickets: '0'
+              archetype_fueled_tickets: '0'
+              apple_tickets: '0'
+              edelman_tickets: '0'
+              facelift_designs_tickets: '0'
+              mmis_tickets: '0'
+              alloy_digital_tickets: '0'
+              mmis_dev_tickets: '0'
+              university_of_colorado_tickets: '0'
+              prime_resource_group_tickets: '0'
+              drupal_watchdog_tickets: '0'
+              codename_design_tickets: '0'
+              highwire_press_tickets: '0'
+              actency_tickets: '0'
+              centretek_tickets: '0'
+              common_sense_media_tickets: '0'
+              tag1_ckeditor_comment_tickets: '0'
+              palantir_tickets: '0'
+              designhammer_tickets: '0'
+              practice_greenhealth_tickets: '0'
+              taunton_interactive_tickets: '0'
+              linux_foundation_tickets: '0'
+              national_retail_foundation_nrf_t: '0'
+              pgh_tickets: '0'
+              daemon_defense_tickets: '0'
+              perforce_software_tickets: '0'
+              leadoutcome_tickets: '0'
+              civicsolar_tickets: '0'
+              maplight_tickets: '0'
+              mcmurry_tmg_tickets: '0'
+              aclu_tickets: '0'
+              tag1_website_tickets: '0'
+              tag1_infrastructure_tickets: '0'
+              stand_for_children_tickets: '0'
+              okoban_tickets: '0'
+              okoban_mindtek_tickets: '0'
+              axelerant_tickets: '0'
+              aclu_affiliates_tickets: '0'
+              mentor_graphics_tickets: '0'
+              brmcloud_tickets: '0'
+              kixify_tickets: '0'
+              young_writers_project_tickets: '0'
+              tag1_billing_overview_private_: '0'
+              lf_cla_tickets: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: support_ticket
+          entity_field: uid
+          plugin_id: user_name
+        support_ticket_type:
+          id: support_ticket_type
+          table: support_ticket
+          field: support_ticket_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: support_ticket_type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: support_ticket_type_op
+            identifier: support_ticket_type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              administrator1: '0'
+              consumersearch_tickets: '0'
+              tag1_jobtrack_tickets: '0'
+              tag1_accounting_tickets: '0'
+              tag1_administrative_tickets: '0'
+              tag1_adbard_tickets: '0'
+              uivote_tickets: '0'
+              bricodepot_tickets: '0'
+              webwise_tickets: '0'
+              parentsclick_tickets: '0'
+              pressflow_tickets: '0'
+              nowpublic_tickets: '0'
+              waste_management_tickets: '0'
+              calorie_count_tickets: '0'
+              sandusky_register_tickets: '0'
+              fsf_tickets: '0'
+              ad_module_tickets: '0'
+              shannon_mccormick_tickets: '0'
+              define_tickets: '0'
+              blue_moon_fiber_arts_tickets: '0'
+              open_source_lab_tickets: '0'
+              ifood_tickets: '0'
+              imagex_tickets: '0'
+              globale_oneness_tickets: '0'
+              dalton_tickets: '0'
+              goldbelt_tickets: '0'
+              empowher_tickets: '0'
+              f123_tickets: '0'
+              tag1_employee: '0'
+              blackmesh_tickets: '0'
+              tag1_theme_tickets: '0'
+              read_tickets: '0'
+              test_client_tickets: '0'
+              examiner_tickets: '0'
+              drupal_association_tickets: '0'
+              tag1_accounting: '0'
+              fishhound_tickets: '0'
+              penton_tickets: '0'
+              mark_boulton_design_tickets: '0'
+              tag1_contractor: '0'
+              acquia_tickets: '0'
+              _account_manager: '0'
+              zinch_tickets: '0'
+              tag1_manager: '0'
+              tidal_tickets: '0'
+              acquia_memcache_tickets: '0'
+              tag1_billable: '0'
+              tag1_terminated: '0'
+              puzzle_nation_tickets: '0'
+              environmental_graffiti_tickets: '0'
+              dustland_media_tickets: '0'
+              tag1_subcontractor: '0'
+              acquia_wiki_pages: '0'
+              _use_ticket_references: '0'
+              mixedbin_media_tickets: '0'
+              ideafit_tickets: '0'
+              inside_higher_ed_tickets: '0'
+              itv_tickets: '0'
+              vibio_tickets: '0'
+              megeve_tourisme_tickets: '0'
+              who2_tickets: '0'
+              polycom_tickets: '0'
+              tag1_contractor_hourly: '0'
+              stratfor_tickets: '0'
+              sunshine_state_news_tickets: '0'
+              funny_monkey_tickets: '0'
+              opensesame_tickets: '0'
+              smithsonian_tickets: '0'
+              tussle_tickets: '0'
+              incap_tickets: '0'
+              strand_scientific_intelligence_t: '0'
+              upto_tickets: '0'
+              are_you_a_human_tickets: '0'
+              center_for_reproductive_rights_t: '0'
+              archetype_tickets: '0'
+              bounty_tickets: '0'
+              bryant_group_tickets: '0'
+              cirracore_tickets: '0'
+              archetype_fueled_tickets: '0'
+              apple_tickets: '0'
+              edelman_tickets: '0'
+              facelift_designs_tickets: '0'
+              mmis_tickets: '0'
+              alloy_digital_tickets: '0'
+              mmis_dev_tickets: '0'
+              university_of_colorado_tickets: '0'
+              prime_resource_group_tickets: '0'
+              drupal_watchdog_tickets: '0'
+              codename_design_tickets: '0'
+              highwire_press_tickets: '0'
+              actency_tickets: '0'
+              centretek_tickets: '0'
+              common_sense_media_tickets: '0'
+              tag1_ckeditor_comment_tickets: '0'
+              palantir_tickets: '0'
+              designhammer_tickets: '0'
+              practice_greenhealth_tickets: '0'
+              taunton_interactive_tickets: '0'
+              linux_foundation_tickets: '0'
+              national_retail_foundation_nrf_t: '0'
+              pgh_tickets: '0'
+              daemon_defense_tickets: '0'
+              perforce_software_tickets: '0'
+              leadoutcome_tickets: '0'
+              civicsolar_tickets: '0'
+              maplight_tickets: '0'
+              mcmurry_tmg_tickets: '0'
+              aclu_tickets: '0'
+              tag1_website_tickets: '0'
+              tag1_infrastructure_tickets: '0'
+              stand_for_children_tickets: '0'
+              okoban_tickets: '0'
+              okoban_mindtek_tickets: '0'
+              axelerant_tickets: '0'
+              aclu_affiliates_tickets: '0'
+              mentor_graphics_tickets: '0'
+              brmcloud_tickets: '0'
+              kixify_tickets: '0'
+              young_writers_project_tickets: '0'
+              tag1_billing_overview_private_: '0'
+              lf_cla_tickets: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: support_ticket
+          entity_field: support_ticket_type
+          plugin_id: bundle
+        status:
+          id: status
+          table: support_ticket_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: false
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Published status'
+            description: null
+            use_operator: false
+            operator: status_op
+            identifier: status
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: Status
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Published
+                operator: '='
+                value: '1'
+              2:
+                title: Unpublished
+                operator: '='
+                value: '0'
+              3:
+                title: ''
+                operator: '='
+                value: ''
+          entity_type: support_ticket
+          entity_field: status
+          plugin_id: boolean
+      sorts: {  }
+      title: 'Support ticket overview'
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'No tickets available.'
+          plugin_id: text_custom
+      relationships:
+        uid:
+          id: uid
+          table: support_ticket_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: author
+          required: true
+          entity_type: support_ticket
+          entity_field: uid
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      cacheable: false
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/support_ticket
+      menu:
+        type: tab
+        title: 'Support Tickets'
+        description: ''
+        parent: system.admin_content
+        weight: -2
+        context: '0'
+        menu_name: admin
+      tab_options:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      cacheable: false


### PR DESCRIPTION
Add admin page at _node/content/support_ticket_ modeled after Content listing, Comment listing, and Files listing that's provided by core. Allows bulk operations.

See https://support.tag1consulting.com/node/155782 
