### PR TITLE
Expose assigned as filter

### DIFF
--- a/modules/support_ticket/config/install/views.view.support_ticket_overview.yml
+++ b/modules/support_ticket/config/install/views.view.support_ticket_overview.yml
@@ -658,7 +658,7 @@ display:
           exposed: true
           expose:
             operator_id: uid_op
-            label: Author
+            label: 'Authored by'
             description: ''
             use_operator: false
             operator: uid_op
@@ -684,6 +684,47 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           entity_type: support_ticket
+          entity_field: uid
+          plugin_id: user_name
+        uid_2:
+          id: uid_2
+          table: users_field_data
+          field: uid
+          relationship: field_assigned_to
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: uid_2_op
+            label: 'Assigned to'
+            description: ''
+            use_operator: false
+            operator: uid_2_op
+            identifier: uid_2
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: user
           entity_field: uid
           plugin_id: user_name
         support_ticket_type:
@@ -804,6 +845,15 @@ display:
           required: true
           entity_type: support_ticket
           entity_field: uid
+          plugin_id: standard
+        field_assigned_to:
+          id: field_assigned_to
+          table: support_ticket__field_assigned_to
+          field: field_assigned_to
+          relationship: none
+          group_type: group
+          admin_label: 'field_assigned_to: User'
+          required: false
           plugin_id: standard
       arguments: {  }
       display_extenders: {  }

--- a/modules/support_ticket/config/install/views.view.support_tickets.yml
+++ b/modules/support_ticket/config/install/views.view.support_tickets.yml
@@ -703,6 +703,46 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: list_field
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: field_assigned_to
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: 'Assigned to'
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: user
+          entity_field: name
+          plugin_id: string
       sorts: {  }
       title: 'Support tickets'
       header: {  }
@@ -721,7 +761,16 @@ display:
             value: 'There are currently no support tickets to display.'
             format: basic_html
           plugin_id: text
-      relationships: {  }
+      relationships:
+        field_assigned_to:
+          id: field_assigned_to
+          table: support_ticket__field_assigned_to
+          field: field_assigned_to
+          relationship: none
+          group_type: group
+          admin_label: 'field_assigned_to: User'
+          required: false
+          plugin_id: standard
       arguments: {  }
       display_extenders: {  }
     cache_metadata:


### PR DESCRIPTION
I've exposed the 'assigned' field on the main ticket listing view and the admin ticket listing view. 

In the main ticket listing (available to all users) I exposed the raw username so there's no autocomplete -- type one or more letters and it'll query for any username with those letters. In the admin ticket listing I exposed actual usernames, so it's autocomplete.  I'm not sure which is better for which use case, or if it's better to be consistent on both views -- feedback there welcome.

https://support.tag1consulting.com/node/157102
