### PR TITLE
Sync with 8.0.0 rc1

### DIFF
--- a/modules/support_ticket/config/install/core.entity_view_display.support_ticket.ticket.default.yml
+++ b/modules/support_ticket/config/install/core.entity_view_display.support_ticket.ticket.default.yml
@@ -66,4 +66,17 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+  title:
+    label: hidden
+    type: string
+    weight: -5
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  uid:
+    label: hidden
+    type: author
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
 hidden: {  }

--- a/modules/support_ticket/config/install/field.field.support_ticket.ticket.field_assigned_to.yml
+++ b/modules/support_ticket/config/install/field.field.support_ticket.ticket.field_assigned_to.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.support_ticket.field_assigned_to
     - support_ticket.type.ticket
-  module:
-    - entity_reference
 id: support_ticket.ticket.field_assigned_to
 field_name: field_assigned_to
 entity_type: support_ticket
@@ -22,7 +20,7 @@ settings:
     include_anonymous: false
     filter:
       type: _none
-    target_bundles: {  }
+    target_bundles: null
     sort:
       field: name
       direction: ASC

--- a/modules/support_ticket/config/install/field.field.support_ticket.ticket.field_related.yml
+++ b/modules/support_ticket/config/install/field.field.support_ticket.ticket.field_related.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.support_ticket.field_related
     - support_ticket.type.ticket
-  module:
-    - entity_reference
 id: support_ticket.ticket.field_related
 field_name: field_related
 entity_type: support_ticket

--- a/modules/support_ticket/config/install/field.field.support_ticket.ticket.field_watchers.yml
+++ b/modules/support_ticket/config/install/field.field.support_ticket.ticket.field_watchers.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.support_ticket.field_watchers
     - support_ticket.type.ticket
-  module:
-    - entity_reference
 id: support_ticket.ticket.field_watchers
 field_name: field_watchers
 entity_type: support_ticket
@@ -22,7 +20,7 @@ settings:
     include_anonymous: true
     filter:
       type: _none
-    target_bundles: {  }
+    target_bundles: null
     sort:
       field: name
       direction: ASC

--- a/modules/support_ticket/config/install/field.storage.comment.field_revision_reference.yml
+++ b/modules/support_ticket/config/install/field.storage.comment.field_revision_reference.yml
@@ -16,3 +16,4 @@ cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/field.storage.support_ticket.body.yml
+++ b/modules/support_ticket/config/install/field.storage.support_ticket.body.yml
@@ -15,3 +15,4 @@ cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/field.storage.support_ticket.field_assigned_to.yml
+++ b/modules/support_ticket/config/install/field.storage.support_ticket.field_assigned_to.yml
@@ -2,17 +2,18 @@ langcode: en
 status: true
 dependencies:
   module:
-    - entity_reference
     - support_ticket
+    - user
 id: support_ticket.field_assigned_to
 field_name: field_assigned_to
 entity_type: support_ticket
 type: entity_reference
 settings:
   target_type: user
-module: entity_reference
+module: core
 locked: false
 cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/field.storage.support_ticket.field_priority.yml
+++ b/modules/support_ticket/config/install/field.storage.support_ticket.field_priority.yml
@@ -35,3 +35,4 @@ cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/field.storage.support_ticket.field_related.yml
+++ b/modules/support_ticket/config/install/field.storage.support_ticket.field_related.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - entity_reference
     - support_ticket
 id: support_ticket.field_related
 field_name: field_related
@@ -10,9 +9,10 @@ entity_type: support_ticket
 type: entity_reference
 settings:
   target_type: support_ticket
-module: entity_reference
+module: core
 locked: false
 cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/field.storage.support_ticket.field_state.yml
+++ b/modules/support_ticket/config/install/field.storage.support_ticket.field_state.yml
@@ -35,3 +35,4 @@ cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/field.storage.support_ticket.field_ticket_update.yml
+++ b/modules/support_ticket/config/install/field.storage.support_ticket.field_ticket_update.yml
@@ -16,3 +16,4 @@ cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/field.storage.support_ticket.field_watchers.yml
+++ b/modules/support_ticket/config/install/field.storage.support_ticket.field_watchers.yml
@@ -2,17 +2,18 @@ langcode: en
 status: true
 dependencies:
   module:
-    - entity_reference
     - support_ticket
+    - user
 id: support_ticket.field_watchers
 field_name: field_watchers
 entity_type: support_ticket
 type: entity_reference
 settings:
   target_type: user
-module: entity_reference
+module: core
 locked: false
 cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/views.view.support_ticket_overview.yml
+++ b/modules/support_ticket/config/install/views.view.support_ticket_overview.yml
@@ -820,6 +820,8 @@ display:
         - user
         - user.permissions
       cacheable: false
+      max-age: 0
+      tags: {  }
   page_1:
     display_plugin: page
     id: page_1
@@ -850,3 +852,5 @@ display:
         - user
         - user.permissions
       cacheable: false
+      max-age: 0
+      tags: {  }

--- a/modules/support_ticket/config/install/views.view.support_tickets.yml
+++ b/modules/support_ticket/config/install/views.view.support_tickets.yml
@@ -732,41 +732,11 @@ display:
         - url.query_args
         - user.permissions
       cacheable: false
-  feed_1:
-    display_plugin: feed
-    id: feed_1
-    display_title: Feed
-    position: 2
-    display_options:
-      sitename_title: true
-      path: rss.xml
-      displays:
-        page_1: page_1
-        default: ''
-      pager:
-        type: some
-        options:
-          items_per_page: 10
-          offset: 0
-      style:
-        type: rss
-        options:
-          description: ''
-          grouping: {  }
-          uses_fields: false
-      row:
-        type: support_ticket_rss
-        options:
-          relationship: none
-          view_mode: rss
-      display_extenders: {  }
-    cache_metadata:
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - user.permissions
-      cacheable: false
+      max-age: 0
+      tags:
+        - 'config:field.storage.support_ticket.field_assigned_to'
+        - 'config:field.storage.support_ticket.field_priority'
+        - 'config:field.storage.support_ticket.field_state'
   page_1:
     display_plugin: page
     id: page_1
@@ -792,3 +762,8 @@ display:
         - url.query_args
         - user.permissions
       cacheable: false
+      max-age: 0
+      tags:
+        - 'config:field.storage.support_ticket.field_assigned_to'
+        - 'config:field.storage.support_ticket.field_priority'
+        - 'config:field.storage.support_ticket.field_state'

--- a/modules/support_ticket/config/install/views.view.users_support_tickets.yml
+++ b/modules/support_ticket/config/install/views.view.users_support_tickets.yml
@@ -731,48 +731,11 @@ display:
           required: true
           plugin_id: standard
       arguments:
-        uid:
-          id: uid
-          table: users_field_data
-          field: uid
-          relationship: field_assigned_to
-          group_type: group
-          admin_label: ''
-          default_action: 'not found'
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: true
-          title: '%1''s tickets'
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:user'
-            fail: 'access denied'
-          validate_options:
-            access: '1'
-            operation: view
-            multiple: '0'
-            restrict_roles: 0
-            roles: {  }
-          break_phrase: false
-          not: false
-          entity_type: user
-          entity_field: uid
-          plugin_id: user_uid
+        field_assigned_to_target_id:
+          id: field_assigned_to_target_id
+          table: support_ticket__field_assigned_to
+          field: field_assigned_to_target_id
+          plugin_id: numeric
       display_extenders: {  }
     cache_metadata:
       contexts:
@@ -782,41 +745,11 @@ display:
         - url.query_args
         - user.permissions
       cacheable: false
-  feed_1:
-    display_plugin: feed
-    id: feed_1
-    display_title: Feed
-    position: 2
-    display_options:
-      sitename_title: true
-      path: rss.xml
-      displays:
-        page_1: page_1
-        default: ''
-      pager:
-        type: some
-        options:
-          items_per_page: 10
-          offset: 0
-      style:
-        type: rss
-        options:
-          description: ''
-          grouping: {  }
-          uses_fields: false
-      row:
-        type: support_ticket_rss
-        options:
-          relationship: none
-          view_mode: rss
-      display_extenders: {  }
-    cache_metadata:
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - user.permissions
-      cacheable: false
+      max-age: 0
+      tags:
+        - 'config:field.storage.support_ticket.field_assigned_to'
+        - 'config:field.storage.support_ticket.field_priority'
+        - 'config:field.storage.support_ticket.field_state'
   page_1:
     display_plugin: page
     id: page_1
@@ -842,3 +775,8 @@ display:
         - url.query_args
         - user.permissions
       cacheable: false
+      max-age: 0
+      tags:
+        - 'config:field.storage.support_ticket.field_assigned_to'
+        - 'config:field.storage.support_ticket.field_priority'
+        - 'config:field.storage.support_ticket.field_state'

--- a/modules/support_ticket/src/Access/SupportTicketRevisionAccessCheck.php
+++ b/modules/support_ticket/src/Access/SupportTicketRevisionAccessCheck.php
@@ -93,15 +93,11 @@ class SupportTicketRevisionAccessCheck implements AccessInterface {
    *   performed.
    * @param string $op
    *   (optional) The specific operation being checked. Defaults to 'view.'
-   * @param string|null $langcode
-   *   (optional) Language code for the variant of the support_ticket. Different
-   *   language variants might have different permissions associated. If NULL, the
-   *   original langcode of the support_ticket is used. Defaults to NULL.
    *
    * @return bool
    *   TRUE if the operation may be performed, FALSE otherwise.
    */
-  public function checkAccess(SupportTicketInterface $support_ticket, AccountInterface $account, $op = 'view', $langcode = NULL) {
+  public function checkAccess(SupportTicketInterface $support_ticket, AccountInterface $account, $op = 'view') {
     $map = array(
       'view' => 'view all revisions',
       'update' => 'revert all revisions',
@@ -120,14 +116,9 @@ class SupportTicketRevisionAccessCheck implements AccessInterface {
       return FALSE;
     }
 
-    // If no language code was provided, default to the support_ticket revision's
-    // langcode.
-    if (empty($langcode)) {
-      $langcode = $support_ticket->language()->getId();
-    }
-
     // Statically cache access by revision ID, language code, user account ID,
     // and operation.
+    $langcode = $support_ticket->language()->getId();
     $cid = $support_ticket->getRevisionId() . ':' . $langcode . ':' . $account->id() . ':' . $op;
 
     if (!isset($this->access[$cid])) {
@@ -152,7 +143,7 @@ class SupportTicketRevisionAccessCheck implements AccessInterface {
         // First check the access to the default revision and finally, if the
         // support_ticket passed in is not the default revision then access to that,
         // too.
-        $this->access[$cid] = $this->supportTicketAccess->access($this->supportTicketStorage->load($support_ticket->id()), $op, $langcode, $account) && ($support_ticket->isDefaultRevision() || $this->supportTicketAccess->access($support_ticket, $op, $langcode, $account));
+        $this->access[$cid] = $this->supportTicketAccess->access($this->supportTicketStorage->load($support_ticket->id()), $op, $account) && ($support_ticket->isDefaultRevision() || $this->supportTicketAccess->access($support_ticket, $op, $account));
       }
     }
 

--- a/modules/support_ticket/src/ContextProvider/SupportTicketRouteContext.php
+++ b/modules/support_ticket/src/ContextProvider/SupportTicketRouteContext.php
@@ -41,18 +41,20 @@ class SupportTicketRouteContext implements ContextProviderInterface {
    */
   public function getRuntimeContexts(array $unqualified_context_ids) {
     $result = [];
-    $context = new Context(new ContextDefinition('entity:support_ticket', NULL, FALSE));
+    $context_definition = new ContextDefinition('entity:support_ticket', NULL, FALSE);
+    $value = NULL;
     if (($route_object = $this->routeMatch->getRouteObject()) && ($route_contexts = $route_object->getOption('parameters')) && isset($route_contexts['support_ticket'])) {
-      if ($suppor_ticket = $this->routeMatch->getParameter('support_ticket')) {
-        $context->setContextValue($support_ticket);
+      if ($support_ticket = $this->routeMatch->getParameter('support_ticket')) {
+        $value = $support_ticket;
       }
     }
     elseif ($this->routeMatch->getRouteName() == 'support_ticket.add') {
       $support_ticket_type = $this->routeMatch->getParameter('support_ticket_type');
-      $context->setContextValue(SupportTicket::create(array('type' => $support_ticket_type->id())));
+      $value = SupportTicket::create(array('type' => $support_ticket_type->id()));
     }
     $cacheability = new CacheableMetadata();
     $cacheability->setCacheContexts(['route']);
+    $context = new Context($context_definition, $value);
     $context->addCacheableDependency($cacheability);
     $result['support_ticket'] = $context;
 

--- a/modules/support_ticket/src/Controller/SupportTicketController.php
+++ b/modules/support_ticket/src/Controller/SupportTicketController.php
@@ -8,7 +8,7 @@
 namespace Drupal\support_ticket\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
@@ -24,7 +24,7 @@ class SupportTicketController extends ControllerBase implements ContainerInjecti
   /**
    * The date formatter service.
    *
-   * @var \Drupal\Core\Datetime\DateFormatter
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
    */
   protected $dateFormatter;
 
@@ -38,12 +38,12 @@ class SupportTicketController extends ControllerBase implements ContainerInjecti
   /**
    * Constructs a SupportTicketController object.
    *
-   * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The date formatter service.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The renderer service.
    */
-  public function __construct(DateFormatter $date_formatter, RendererInterface $renderer) {
+  public function __construct(DateFormatterInterface $date_formatter, RendererInterface $renderer) {
     $this->dateFormatter = $date_formatter;
     $this->renderer = $renderer;
   }

--- a/modules/support_ticket/src/Entity/SupportTicket.php
+++ b/modules/support_ticket/src/Entity/SupportTicket.php
@@ -149,27 +149,7 @@ class SupportTicket extends ContentEntityBase implements SupportTicketInterface 
 
     return \Drupal::entityManager()
       ->getAccessControlHandler($this->entityTypeId)
-      ->access($this, $operation, $this->prepareLangcode(), $account, $return_as_object);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function prepareLangcode() {
-    $langcode = $this->language()->getId();
-    // If the Language module is enabled, try to use the language from content
-    // negotiation.
-    if (\Drupal::moduleHandler()->moduleExists('language')) {
-      // Load languages the support ticket exists in.
-      $support_ticket_translations = $this->getTranslationLanguages();
-      // Load the language from content negotiation.
-      $content_negotiation_langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
-      // If there is a translation available, use it.
-      if (isset($support_ticket_translations[$content_negotiation_langcode])) {
-        $langcode = $content_negotiation_langcode;
-      }
-    }
-    return $langcode;
+      ->access($this, $operation, $account, $return_as_object);
   }
 
   /**
@@ -200,13 +180,6 @@ class SupportTicket extends ContentEntityBase implements SupportTicketInterface 
   public function setCreatedTime($timestamp) {
     $this->set('created', $timestamp);
     return $this;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getChangedTime() {
-    return $this->get('changed')->value;
   }
 
   /**
@@ -436,6 +409,7 @@ class SupportTicket extends ContentEntityBase implements SupportTicketInterface 
       ->setDescription(t('Briefly describe the changes you have made.'))
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
+      ->setDefaultValue('')
       ->setDisplayOptions('form', array(
         'type' => 'string_textarea',
         'weight' => 25,

--- a/modules/support_ticket/src/Plugin/EntityReferenceSelection/SupportTicketSelection.php
+++ b/modules/support_ticket/src/Plugin/EntityReferenceSelection/SupportTicketSelection.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\support_ticket\Plugin\EntityReferenceSelection;
 
-use Drupal\Core\Entity\Plugin\EntityReferenceSelection\SelectionBase;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -21,7 +21,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   weight = 1
  * )
  */
-class SupportTicketSelection extends SelectionBase {
+class SupportTicketSelection extends DefaultSelection {
 
   /**
    * {@inheritdoc}

--- a/modules/support_ticket/src/Plugin/views/row/Rss.php
+++ b/modules/support_ticket/src/Plugin/views/row/Rss.php
@@ -122,7 +122,7 @@ class Rss extends RssPluginBase {
       ),
       array(
         'key' => 'dc:creator',
-        'value' => $support_ticket->getOwner()->getUsername(),
+        'value' => $support_ticket->getOwner()->getDisplayName(),
       ),
       array(
         'key' => 'guid',

--- a/modules/support_ticket/src/SupportTicketAccessControlHandler.php
+++ b/modules/support_ticket/src/SupportTicketAccessControlHandler.php
@@ -36,7 +36,7 @@ class SupportTicketAccessControlHandler extends EntityAccessControlHandler imple
   /**
    * {@inheritdoc}
    */
-  public function access(EntityInterface $entity, $operation, $langcode = LanguageInterface::LANGCODE_DEFAULT, AccountInterface $account = NULL, $return_as_object = FALSE) {
+  public function access(EntityInterface $entity, $operation, AccountInterface $account = NULL, $return_as_object = FALSE) {
     $account = $this->prepareUser($account);
 
     if ($account->hasPermission('administer support tickets')) {
@@ -47,7 +47,7 @@ class SupportTicketAccessControlHandler extends EntityAccessControlHandler imple
       $result = AccessResult::forbidden()->cachePerPermissions();
       return $return_as_object ? $result : $result->isAllowed();
     }
-    $result = parent::access($entity, $operation, $langcode, $account, TRUE)->cachePerPermissions();
+    $result = parent::access($entity, $operation, $account, TRUE)->cachePerPermissions();
     return $return_as_object ? $result : $result->isAllowed();
   }
 
@@ -69,13 +69,11 @@ class SupportTicketAccessControlHandler extends EntityAccessControlHandler imple
   /**
    * {@inheritdoc}
    */
-  protected function checkAccess(EntityInterface $support_ticket, $operation, $langcode, AccountInterface $account) {
+  protected function checkAccess(EntityInterface $support_ticket, $operation, AccountInterface $account) {
     /** @var \Drupal\support_ticket\SupportTicketInterface $support_ticket */
-    /** @var \Drupal\support_ticket\SupportTicketInterface $translation */
-    $translation = $support_ticket->getTranslation($langcode);
     // Fetch information from the support_ticket object if possible.
-    $status = $translation->isPublished();
-    $uid = $translation->getOwnerId();
+    $status = $support_ticket->isPublished();
+    $uid = $support_ticket->getOwnerId();
 
     // Check if authors can view their own unpublished support tickets.
     if ($operation === 'view' && !$status && $account->hasPermission('view own unpublished support tickets') && $account->isAuthenticated() && $account->id() == $uid) {

--- a/modules/support_ticket/src/SupportTicketInterface.php
+++ b/modules/support_ticket/src/SupportTicketInterface.php
@@ -140,13 +140,4 @@ interface SupportTicketInterface extends ContentEntityInterface, EntityChangedIn
    *   The called support ticket entity.
    */
   public function setRevisionAuthorId($uid);
-
-  /**
-   * Prepares the langcode for a support ticket.
-   *
-   * @return string
-   *   The langcode for this support ticket.
-   */
-  public function prepareLangcode();
-
 }

--- a/modules/support_ticket/src/SupportTicketListBuilder.php
+++ b/modules/support_ticket/src/SupportTicketListBuilder.php
@@ -8,7 +8,7 @@
 namespace Drupal\support_ticket;
 
 use Drupal\Component\Utility\SafeMarkup;
-use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
 use Drupal\Core\Entity\EntityStorageInterface;
@@ -27,7 +27,7 @@ class SupportTicketListBuilder extends EntityListBuilder {
   /**
    * The date formatter service.
    *
-   * @var \Drupal\Core\Datetime\DateFormatter
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
    */
   protected $dateFormatter;
 
@@ -45,12 +45,12 @@ class SupportTicketListBuilder extends EntityListBuilder {
    *   The entity type definition.
    * @param \Drupal\Core\Entity\EntityStorageInterface $storage
    *   The entity storage class.
-   * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The date formatter service.
    * @param \Drupal\Core\Routing\RedirectDestinationInterface $redirect_destination
    *   The redirect destination service.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, DateFormatter $date_formatter, RedirectDestinationInterface $redirect_destination) {
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, DateFormatterInterface $date_formatter, RedirectDestinationInterface $redirect_destination) {
     parent::__construct($entity_type, $storage);
 
     $this->dateFormatter = $date_formatter;

--- a/modules/support_ticket/src/SupportTicketViewBuilder.php
+++ b/modules/support_ticket/src/SupportTicketViewBuilder.php
@@ -21,13 +21,13 @@ class SupportTicketViewBuilder extends EntityViewBuilder {
   /**
    * {@inheritdoc}
    */
-  public function buildComponents(array &$build, array $entities, array $displays, $view_mode, $langcode = NULL) {
+  public function buildComponents(array &$build, array $entities, array $displays, $view_mode) {
     /** @var \Drupal\support_ticket\SupportTicketInterface[] $entities */
     if (empty($entities)) {
       return;
     }
 
-    parent::buildComponents($build, $entities, $displays, $view_mode, $langcode);
+    parent::buildComponents($build, $entities, $displays, $view_mode);
 
     foreach ($entities as $id => $entity) {
       $bundle = $entity->bundle();
@@ -38,7 +38,7 @@ class SupportTicketViewBuilder extends EntityViewBuilder {
           '#lazy_builder' => [get_called_class() . '::renderLinks', [
             $entity->id(),
             $view_mode,
-            $langcode,
+            $entity->language()->getId(),
           ]],
           '#create_placeholder' => TRUE,
         );
@@ -131,9 +131,9 @@ class SupportTicketViewBuilder extends EntityViewBuilder {
   /**
    * {@inheritdoc}
    */
-  protected function alterBuild(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode, $langcode = NULL) {
+  protected function alterBuild(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
     /** @var \Drupal\support_ticket\SupportTicketInterface $entity */
-    parent::alterBuild($build, $entity, $display, $view_mode, $langcode);
+    parent::alterBuild($build, $entity, $display, $view_mode);
     if ($entity->id()) {
       $build['#contextual_links']['support_ticket'] = array(
         'route_parameters' =>array('support_ticket' => $entity->id()),

--- a/modules/support_ticket/support_ticket.api.php
+++ b/modules/support_ticket/support_ticket.api.php
@@ -36,15 +36,13 @@ use Drupal\Core\Access\AccessResult;
  *   - "view"
  * @param \Drupal\Core\Session\AccountInterface $account
  *   The user object to perform the access check operation on.
- * @param string $langcode
- *   The language code to perform the access check operation on.
  *
  * @return \Drupal\Core\Access\AccessResultInterface
  *    The access result.
  *
  * @ingroup support_ticket_access
  */
-function hook_support_ticket_access(\Drupal\support_ticket\SupportTicketInterface $support_ticket, $op, \Drupal\Core\Session\AccountInterface $account, $langcode) {
+function hook_support_ticket_access(\Drupal\support_ticket\SupportTicketInterface $support_ticket, $op, \Drupal\Core\Session\AccountInterface $account) {
   $type = $support_ticket->bundle();
 
   switch ($op) {

--- a/modules/support_ticket/support_ticket.info.yml
+++ b/modules/support_ticket/support_ticket.info.yml
@@ -7,5 +7,4 @@ version: VERSION
 dependencies:
   - text
   - options
-  - entity_reference
   - diff


### PR DESCRIPTION
Merges in core changes to node module through 8.0.0-rc1, from the following issues:
- https://www.drupal.org/node/2579847 /node/add is lacking cacheability metadata, causes problems when cached by Dynamic Page Cache and "Use admin theme when editing or creating content" is turned off
- https://www.drupal.org/node/2508884 Make contexts immutable
- https://www.drupal.org/node/2506213 Update content entity changed timestamp on UI save
- https://www.drupal.org/node/2571647 Create DateFormatterInterface
- https://www.drupal.org/node/2578559 Have ViewsSelection no longer extend SelectionBase
- https://www.drupal.org/node/2072945 Remove the $langcode parameter in EntityAccessControllerInterface::access() and friends

https://support.tag1consulting.com/node/162902
