### PR TITLE
Store ticket diffs in custom field

### DIFF
--- a/modules/support_ticket/config/install/core.entity_form_display.comment.support_ticket_update.default.yml
+++ b/modules/support_ticket/config/install/core.entity_form_display.comment.support_ticket_update.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - comment.type.support_ticket_update
     - field.field.comment.support_ticket_update.comment_body
+    - field.field.comment.support_ticket_update.field_revision_changes
     - field.field.comment.support_ticket_update.field_revision_reference
   module:
     - text
@@ -23,6 +24,13 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_revision_changes:
+    weight: 3
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
   subject:
     type: string_textfield
     weight: 1

--- a/modules/support_ticket/config/install/core.entity_form_display.comment.support_ticket_update.default.yml
+++ b/modules/support_ticket/config/install/core.entity_form_display.comment.support_ticket_update.default.yml
@@ -24,13 +24,6 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-  field_revision_changes:
-    weight: 3
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-    type: text_textarea
   subject:
     type: string_textfield
     weight: 1
@@ -39,4 +32,5 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
+  field_revision_changes: true
   field_revision_reference: true

--- a/modules/support_ticket/config/install/core.entity_view_display.comment.support_ticket_update.default.yml
+++ b/modules/support_ticket/config/install/core.entity_view_display.comment.support_ticket_update.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - comment.type.support_ticket_update
     - field.field.comment.support_ticket_update.comment_body
+    - field.field.comment.support_ticket_update.field_revision_changes
     - field.field.comment.support_ticket_update.field_revision_reference
   module:
     - text
@@ -18,8 +19,14 @@ content:
     weight: 0
     settings: {  }
     third_party_settings: {  }
-  links:
+  field_revision_changes:
     weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+  links:
+    weight: 2
     settings: {  }
     third_party_settings: {  }
 hidden:

--- a/modules/support_ticket/config/install/field.field.comment.support_ticket_update.field_revision_changes.yml
+++ b/modules/support_ticket/config/install/field.field.comment.support_ticket_update.field_revision_changes.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.support_ticket_update
+    - field.storage.comment.field_revision_changes
+  module:
+    - text
+id: comment.support_ticket_update.field_revision_changes
+field_name: field_revision_changes
+entity_type: comment
+bundle: support_ticket_update
+label: 'Revision changes'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/support_ticket/config/install/field.storage.comment.field_revision_changes.yml
+++ b/modules/support_ticket/config/install/field.storage.comment.field_revision_changes.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - text
+id: comment.field_revision_changes
+field_name: field_revision_changes
+entity_type: comment
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/support_ticket/config/install/support_ticket.settings.yml
+++ b/modules/support_ticket/config/install/support_ticket.settings.yml
@@ -4,3 +4,4 @@ support_ticket_type_settings:
     comment_diff_revision_reference: field_revision_reference
     view_mode: support_ticket_metadata_changes
     filter_format: full_html
+    comment_diff_revision_changes: field_revision_changes

--- a/modules/support_ticket/config/install/system.action.support_ticket_delete_action.yml
+++ b/modules/support_ticket/config/install/system.action.support_ticket_delete_action.yml
@@ -1,9 +1,10 @@
-id: support_ticket_delete_action
-label: 'Delete support ticket'
-status: true
 langcode: en
-type: support_ticket
-plugin: support_ticket_delete_action
+status: true
 dependencies:
   module:
     - support_ticket
+id: support_ticket_delete_action
+label: 'Delete support ticket'
+type: support_ticket
+plugin: support_ticket_delete_action
+configuration: {  }

--- a/modules/support_ticket/config/install/system.action.support_ticket_lock_action.yml
+++ b/modules/support_ticket/config/install/system.action.support_ticket_lock_action.yml
@@ -1,9 +1,10 @@
-id: support_ticket_lock_action
-label: 'Lock support ticket'
-status: true
 langcode: en
-type: support_ticket
-plugin: support_ticket_lock_action
+status: true
 dependencies:
   module:
     - support_ticket
+id: support_ticket_lock_action
+label: 'Lock support ticket'
+type: support_ticket
+plugin: support_ticket_lock_action
+configuration: {  }

--- a/modules/support_ticket/config/install/system.action.support_ticket_publish_action.yml
+++ b/modules/support_ticket/config/install/system.action.support_ticket_publish_action.yml
@@ -1,9 +1,10 @@
-id: support_ticket_publish_action
-label: 'Publish support ticket'
-status: true
 langcode: en
-type: support_ticket
-plugin: support_ticket_publish_action
+status: true
 dependencies:
   module:
     - support_ticket
+id: support_ticket_publish_action
+label: 'Publish support ticket'
+type: support_ticket
+plugin: support_ticket_publish_action
+configuration: {  }

--- a/modules/support_ticket/config/install/system.action.support_ticket_save_action.yml
+++ b/modules/support_ticket/config/install/system.action.support_ticket_save_action.yml
@@ -1,9 +1,10 @@
-id: support_ticket_save_action
-label: 'Save support ticket'
-status: true
 langcode: en
-type: support_ticket
-plugin: support_ticket_save_action
+status: true
 dependencies:
   module:
     - support_ticket
+id: support_ticket_save_action
+label: 'Save support ticket'
+type: support_ticket
+plugin: support_ticket_save_action
+configuration: {  }

--- a/modules/support_ticket/config/install/system.action.support_ticket_unlock_action.yml
+++ b/modules/support_ticket/config/install/system.action.support_ticket_unlock_action.yml
@@ -1,9 +1,10 @@
-id: support_ticket_unlock_action
-label: 'Unlock support ticket'
-status: true
 langcode: en
-type: support_ticket
-plugin: support_ticket_unlock_action
+status: true
 dependencies:
   module:
     - support_ticket
+id: support_ticket_unlock_action
+label: 'Unlock support ticket'
+type: support_ticket
+plugin: support_ticket_unlock_action
+configuration: {  }

--- a/modules/support_ticket/config/install/system.action.support_ticket_unpublish_action.yml
+++ b/modules/support_ticket/config/install/system.action.support_ticket_unpublish_action.yml
@@ -1,9 +1,10 @@
-id: support_ticket_unpublish_action
-label: 'Unpublish support ticket'
-status: true
 langcode: en
-type: support_ticket
-plugin: support_ticket_unpublish_action
+status: true
 dependencies:
   module:
     - support_ticket
+id: support_ticket_unpublish_action
+label: 'Unpublish support ticket'
+type: support_ticket
+plugin: support_ticket_unpublish_action
+configuration: {  }

--- a/modules/support_ticket/support_ticket.module
+++ b/modules/support_ticket/support_ticket.module
@@ -646,7 +646,7 @@ function support_ticket_form_support_ticket_type_edit_form_alter(&$form, FormSta
     $config = \Drupal::configFactory()->get('support_ticket.settings');
 
     $form['diff'] = array(
-      '#title' => t('Revision comparisons'),
+      '#title' => t('Revision changes'),
       '#type' => 'details',
       '#group' => 'additional_settings',
       '#tree' => FALSE,
@@ -667,8 +667,8 @@ function support_ticket_form_support_ticket_type_edit_form_alter(&$form, FormSta
     }
     $form['diff']['comment_diff_field'] = array(
       '#type' => 'select',
-      '#title' => t('Comment field'),
-      '#description' => t('Where to write comparison comments.'),
+      '#title' => t('Support ticket comment field'),
+      '#description' => t('Support ticket comment field where to write change comments.'),
       '#options' => $options,
       '#weight' => 12,
       '#default_value' => $comment_field,
@@ -679,23 +679,35 @@ function support_ticket_form_support_ticket_type_edit_form_alter(&$form, FormSta
     // if '- None -' is selected above.
 
     if (!empty($comment_field)) {
-      $options = array();
+      $revision_reference_options = $revision_changes_options = array();
       $field_storage = FieldStorageConfig::loadByName('support_ticket', $comment_field);
       $comment_type = $field_storage->getSetting('comment_type');
       $fields = \Drupal::entityManager()->getFieldDefinitions('comment', $comment_type);
       foreach ($fields as $field) {
-        if ($field->getType() == 'integer' && ($field_name = $field->getName()) != 'cid') {
-          $options[$field_name] = $field->getLabel();
+        if ($field->getType() == 'integer' && ($revision_reference_field = $field->getName()) != 'cid') {
+          $revision_reference_options[$revision_reference_field] = $field->getLabel();
+        }
+        if ($field->getType() == 'text_long' && $revision_changes_field = $field->getName()) {
+          $revision_changes_options[$revision_changes_field] = $field->getLabel();
         }
       }
 
       $form['diff']['comment_diff_revision_reference'] = array(
         '#type' => 'select',
-        '#title' => t('Revision field'),
+        '#title' => t('Revision ID integer field'),
         '#description' => t('Integer field in %comment_field_label to store revision ID that caused this comment.', array('%comment_field_label' => $comment_field_label)),
-        '#options' => $options,
+        '#options' => $revision_reference_options,
         '#weight' => 14,
         '#default_value' => _support_ticket_comment_diff_revision_reference($type->id(), $comment_type),
+        '#empty_value' => '',
+      );
+      $form['diff']['comment_diff_revision_changes'] = array(
+        '#type' => 'select',
+        '#title' => t('Revision changes text field'),
+        '#description' => t('Long text field in %comment_field_label to store the revision changes comment.', array('%comment_field_label' => $comment_field_label)),
+        '#options' => $revision_changes_options,
+        '#weight' => 14,
+        '#default_value' => _support_ticket_comment_diff_revision_changes($type->id(), $comment_type),
         '#empty_value' => '',
       );
     }
@@ -709,7 +721,7 @@ function support_ticket_form_support_ticket_type_edit_form_alter(&$form, FormSta
     $form['diff']['filter_format'] = array(
       '#type' => 'select',
       '#title' => t('Filter format'),
-      '#description' => t('Which filter format to apply to comparison comments.'),
+      '#description' => t('Which filter format to apply to change comments.'),
       '#options' => $options,
       '#weight' => 16,
       '#default_value' => $config->get('support_ticket_type_settings.' . $type->id() . '.filter_format'),
@@ -766,7 +778,7 @@ function _support_ticket_comment_diff_field($entity_type) {
 }
 
 /**
- * Determine comment field to write revision references into.
+ * Determine integer comment field to write revision references into.
  *
  * @param \Drupal\support_ticket\SupportTicketTypeInterface $entity_type
  *   The support ticket entity type.
@@ -796,6 +808,38 @@ function _support_ticket_comment_diff_revision_reference($entity_type, $comment_
 }
 
 /**
+ * Determine text comment field to write revision changes into.
+ *
+ * @param \Drupal\support_ticket\SupportTicketTypeInterface $entity_type
+ *   The support ticket entity type.
+ * @param string $comment_type
+ *   The comment type.
+ *
+ * @return string $default
+ *   The field name.
+ */
+function _support_ticket_comment_diff_revision_changes($entity_type, $comment_type) {
+  $config = \Drupal::configFactory()->get('support_ticket.settings');
+  $default = $config->get('support_ticket_type_settings.' . $entity_type . '.comment_diff_revision_changes');
+
+  if ($default === NULL) {
+    $fields = \Drupal::entityManager()->getFieldDefinitions('comment', $comment_type);
+    foreach ($fields as $field) {
+      if ($field->getType() == 'text_long' && ($field_name = $field->getName()) != 'comment_body') {
+        $default = $field_name;
+        \Drupal::configFactory()->getEditable('support_ticket.settings')
+          ->set('support_ticket_type_settings.' . $entity_type . '.comment_diff_revision_changes', $default)
+          ->save();
+        break;
+      }
+    }
+  }
+  return $default;
+}
+
+
+
+/**
  * Submit handler for forms with menu options.
  *
  * @see support_ticket_form_support_ticket_type_edit_form_alter().
@@ -807,5 +851,6 @@ function support_ticket_form_support_ticket_type_form_submit(&$form, $form_state
     ->set('support_ticket_type_settings.' . $type->id() . '.filter_format', $form_state->getValue('filter_format'))
     ->set('support_ticket_type_settings.' . $type->id() . '.comment_diff_field', $form_state->getValue('comment_diff_field'))
     ->set('support_ticket_type_settings.' . $type->id() . '.comment_diff_revision_reference', $form_state->getValue('comment_diff_revision_reference'))
+    ->set('support_ticket_type_settings.' . $type->id() . '.comment_diff_revision_changes', $form_state->getValue('comment_diff_revision_changes'))
     ->save();
 }

--- a/modules/support_ticket/support_ticket.module
+++ b/modules/support_ticket/support_ticket.module
@@ -257,6 +257,12 @@ function support_ticket_entity_update($support_ticket) {
       // There's no field to write revision diffs into, so skip calculating a diff.
       return;
     }
+    $field_storage = FieldStorageConfig::loadByName('support_ticket', $field_name);
+    $comment_type = $field_storage->getSetting('comment_type');
+    if (!$diff_revision_changes_field = _support_ticket_comment_diff_revision_changes($type->id(), $comment_type)) {
+      // There's no field to write revision diffs into, so skip calculating a diff.
+      return;
+    }
 
     // Load some variables we need to generate a properly formatted diff.
     $config = \Drupal::configFactory()->get('support_ticket.settings');
@@ -320,15 +326,18 @@ function support_ticket_entity_update($support_ticket) {
     );
 
     // Store generated diff as a comment.
-    $field_storage = FieldStorageConfig::loadByName('support_ticket', $field_name);
-    $comment_type = $field_storage->getSetting('comment_type');
     $diff_comment = array(
       'cid' => NULL,
+      'uid' => \Drupal::currentUser()->id(),
       'entity_id' => $support_ticket->id(),
       'entity_type' => 'support_ticket',
       'field_name' => $field_name,
       'pid' => 0,
       'comment_body' => array(
+        'value' => '<em>' . t('Automatically generated:') . '</em>',
+        'format' => $filter_format,
+      ),
+      $diff_revision_changes_field => array(
         'value' => \Drupal::service('renderer')->renderPlain($build['diff']),
         'format' => $filter_format,
       ),
@@ -667,8 +676,8 @@ function support_ticket_form_support_ticket_type_edit_form_alter(&$form, FormSta
     }
     $form['diff']['comment_diff_field'] = array(
       '#type' => 'select',
-      '#title' => t('Support ticket comment field'),
-      '#description' => t('Support ticket comment field where to write change comments.'),
+      '#title' => t('Comment field'),
+      '#description' => t('The comment field in the %type support ticket type where change comments will be written.', array('%type' => $type->label())),
       '#options' => $options,
       '#weight' => 12,
       '#default_value' => $comment_field,
@@ -695,7 +704,7 @@ function support_ticket_form_support_ticket_type_edit_form_alter(&$form, FormSta
       $form['diff']['comment_diff_revision_reference'] = array(
         '#type' => 'select',
         '#title' => t('Revision ID integer field'),
-        '#description' => t('Integer field in %comment_field_label to store revision ID that caused this comment.', array('%comment_field_label' => $comment_field_label)),
+        '#description' => t('Integer field in %comment_field_label comment field to store the revision ID that caused these revision changes.', array('%comment_field_label' => $comment_field_label)),
         '#options' => $revision_reference_options,
         '#weight' => 14,
         '#default_value' => _support_ticket_comment_diff_revision_reference($type->id(), $comment_type),
@@ -703,8 +712,8 @@ function support_ticket_form_support_ticket_type_edit_form_alter(&$form, FormSta
       );
       $form['diff']['comment_diff_revision_changes'] = array(
         '#type' => 'select',
-        '#title' => t('Revision changes text field'),
-        '#description' => t('Long text field in %comment_field_label to store the revision changes comment.', array('%comment_field_label' => $comment_field_label)),
+        '#title' => t('Revision changes long text field'),
+        '#description' => t('Long text field in %comment_field_label comment field to store the revision changes.', array('%comment_field_label' => $comment_field_label)),
         '#options' => $revision_changes_options,
         '#weight' => 14,
         '#default_value' => _support_ticket_comment_diff_revision_changes($type->id(), $comment_type),
@@ -721,7 +730,7 @@ function support_ticket_form_support_ticket_type_edit_form_alter(&$form, FormSta
     $form['diff']['filter_format'] = array(
       '#type' => 'select',
       '#title' => t('Filter format'),
-      '#description' => t('Which filter format to apply to change comments.'),
+      '#description' => t('Which filter format to apply to revision changes.'),
       '#options' => $options,
       '#weight' => 16,
       '#default_value' => $config->get('support_ticket_type_settings.' . $type->id() . '.filter_format'),


### PR DESCRIPTION
Store revision diffs in a custom (configurable) field. By default, this field isn't editable. We also track the author making the changes.

https://support.tag1consulting.com/node/161272
