### PR TITLE
Add locked-down format that lets through only the diff boilerplate markup.

### DIFF
--- a/modules/support_ticket/config/install/filter.format.support_ticket_diff.yml
+++ b/modules/support_ticket/config/install/filter.format.support_ticket_diff.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Support ticket diff'
+format: support_ticket_diff
+weight: 0
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<em class> <span class> <table class data-striping> <tbody> <tr class> <td colspan class>'
+      filter_html_help: false
+      filter_html_nofollow: false

--- a/modules/support_ticket/config/install/support_ticket.settings.yml
+++ b/modules/support_ticket/config/install/support_ticket.settings.yml
@@ -2,5 +2,5 @@ support_ticket_type_settings:
   ticket:
     comment_diff_field: field_ticket_update
     comment_diff_revision_reference: field_revision_reference
-    filter_format: full_html
+    filter_format: support_ticket_diff
     comment_diff_revision_changes: field_revision_changes


### PR DESCRIPTION
See tag1 #167782.

This is needed for both testing (which starts from scratch re: input formats) and sites without a full_html format (which was probably a bad idea to use here in the first place, all things considered.)
