### PR TITLE
Give priority sortable key

### DIFF
--- a/modules/support_ticket/config/install/field.field.support_ticket.ticket.field_priority.yml
+++ b/modules/support_ticket/config/install/field.field.support_ticket.ticket.field_priority.yml
@@ -16,7 +16,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: normal
+    value: '115'
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/modules/support_ticket/config/install/field.storage.support_ticket.field_priority.yml
+++ b/modules/support_ticket/config/install/field.storage.support_ticket.field_priority.yml
@@ -11,22 +11,22 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: lowest
+      value: '105'
       label: lowest
     -
-      value: low
+      value: '110'
       label: low
     -
-      value: normal
+      value: '115'
       label: normal
     -
-      value: high
+      value: '120'
       label: high
     -
-      value: urgent
+      value: '125'
       label: urgent
     -
-      value: critical
+      value: '130'
       label: critical
   allowed_values_function: ''
 module: options

--- a/modules/support_ticket/config/install/views.view.support_tickets.yml
+++ b/modules/support_ticket/config/install/views.view.support_tickets.yml
@@ -658,12 +658,12 @@ display:
           admin_label: ''
           operator: or
           value:
-            lowest: lowest
-            low: low
-            normal: normal
-            high: high
-            urgent: urgent
-            critical: critical
+            105: '105'
+            110: '110'
+            115: '115'
+            120: '120'
+            125: '125'
+            130: '130'
           group: 1
           exposed: true
           expose:

--- a/modules/support_ticket/config/install/views.view.users_support_tickets.yml
+++ b/modules/support_ticket/config/install/views.view.users_support_tickets.yml
@@ -656,12 +656,12 @@ display:
           admin_label: ''
           operator: or
           value:
-            lowest: lowest
-            low: low
-            normal: normal
-            high: high
-            urgent: urgent
-            critical: critical
+            105: '105'
+            110: '110'
+            115: '115'
+            120: '120'
+            125: '125'
+            130: '130'
           group: 1
           exposed: true
           expose:

--- a/modules/support_ticket/support_ticket.install
+++ b/modules/support_ticket/support_ticket.install
@@ -24,5 +24,8 @@ function support_ticket_install() {
     }
     $config->set('entity.support_ticket' . '.' . $field_key, $compare);
   }
+  // The Priority field is a list_string configured as "key => label", we need
+  // to compare the "label" to see human readable changes.
+  $config->set('field_types.list_string.settings.compare', 'label');
   $config->save();
 }


### PR DESCRIPTION
Fix so ticket listings can be sorted by Priority by given the Priority field a sortable key. Left plenty of space between key values so additional priorities can be added wherever desired.

https://support.tag1consulting.com/node/155772
