### PR TITLE
Tag1 #155782 -- fix missing clause on status permission check.

### DIFF
--- a/modules/support_ticket/src/Plugin/views/filter/Status.php
+++ b/modules/support_ticket/src/Plugin/views/filter/Status.php
@@ -27,7 +27,7 @@ class Status extends FilterPluginBase {
 
   public function query() {
     $table = $this->ensureMyTable();
-    $this->query->addWhereExpression($this->options['group'], "$table.status = 1 OR ($table.uid = ***CURRENT_USER*** AND ***CURRENT_USER*** <> 0 AND ***VIEW_OWN_UNPUBLISHED_SUPPORT_TICKETS*** = 1)");
+    $this->query->addWhereExpression($this->options['group'], "$table.status = 1 OR ($table.uid = ***CURRENT_USER*** AND ***CURRENT_USER*** <> 0 AND ***VIEW_OWN_UNPUBLISHED_SUPPORT_TICKETS*** = 1) OR ***ADMINISTER_SUPPORT_TICKETS*** = 1");
   }
 
   /**


### PR DESCRIPTION
This was fairly obvious when comparing to node. I didn't test this but it now matches the pattern that node used (except using the admin permission instead of bypass node access control permission)
