### PR TITLE
Fix typo that is causing failures on 8.0.0.

### DIFF
--- a/modules/support_ticket/src/SupportTicketViewsData.php
+++ b/modules/support_ticket/src/SupportTicketViewsData.php
@@ -229,7 +229,7 @@ class SupportTicketViewsData extends EntityViewsData {
         'title' => t('Support ticket'),
         'label' => t('Get the actual support ticket from a support ticket revision.'),
       ),
-    ) + $data['support_ticket_revision']['vid'];
+    ) + $data['support_ticket_field_revision']['vid'];
 
     $data['support_ticket_field_revision']['langcode']['help'] = t('The language the original ticket is in.');
 


### PR DESCRIPTION
Since 8.0.0 has the data structures tidied up, we have to be sure and merge in the right thing, not the accidental copy that ended up elsewhere in the array.
